### PR TITLE
Add cycle_explain function to Explainer

### DIFF
--- a/hshap/src.py
+++ b/hshap/src.py
@@ -189,3 +189,33 @@ class Explainer:
                 saliency_map, shifts=(roll_row, roll_column), dims=(1, 2)
             )
         return saliency_map
+
+    def cycle_explain(
+        self,
+        x: Tensor,
+        label: int,
+        s: int,
+        R: list[int],
+        A: list[int],
+        **kwargs,
+    ):
+        saliency_map = torch.zeros(1, self.size[1], self.size[2])
+        for r in R:
+            for a in A:
+                if r == 0 and a != 0:
+                    continue
+                else:
+                    roll_row = -int(r * np.sin(a))
+                    roll_column = int(r * np.cos(a))
+
+                    saliency_map += self.explain(
+                        x.clone(),
+                        label=label,
+                        s=s,
+                        roll_row=roll_row,
+                        roll_column=roll_column,
+                        **kwargs,
+                    )
+        saliency_map /= ((len(R) - 1) * len(A)) + 1
+        saliency_map.squeeze_()
+        return saliency_map

--- a/hshap/test_src.py
+++ b/hshap/test_src.py
@@ -113,3 +113,22 @@ def test_explainer():
             roll_column=1,
         ),
     ).all()
+
+    expected_saliency_map = torch.zeros(1, 64, 64)
+    expected_saliency_map[:, 1, 1] = 1
+    expected_saliency_map[:, 2, 2] = 1
+    assert torch.eq(
+        expected_saliency_map,
+        hexp.cycle_explain(
+            x=x[1],
+            label=1,
+            s=1,
+            R=[0, 1],
+            A=[0, np.pi / 2, np.pi, 3 * np.pi / 2],
+            threshold_mode="absolute",
+            threshold=0.0,
+            softmax_activation=False,
+            batch_size=2,
+            binary_map=True,
+        ),
+    ).all()


### PR DESCRIPTION
This PR adds the method `cycle_explain` to the `Explainer` class. 

`cycle_explain` computes the saliency map for many partitions by cycling the image along its axis, and finally averages the results.